### PR TITLE
Fix wrong axis in weighted argmax decoder

### DIFF
--- a/torchcrepe/decode.py
+++ b/torchcrepe/decode.py
@@ -25,7 +25,7 @@ def weighted_argmax(logits):
 
     # Find bounds of analysis window
     start = torch.max(torch.tensor(0, device=logits.device), bins - 4)
-    end = torch.min(torch.tensor(logits.size(2), device=logits.device), bins + 5)
+    end = torch.min(torch.tensor(logits.size(1), device=logits.device), bins + 5)
 
     # Mask out everything outside of window
     for batch in range(logits.size(0)):


### PR DESCRIPTION
At `decode.py`, line 28:
```python
  # Find bounds of analysis window
  start = torch.max(torch.tensor(0, device=logits.device), bins - 4)
  end = torch.min(torch.tensor(logits.size(2), device=logits.device), bins + 5)  # <-- wrong axis here
```
Should be `logits.size(1)` instead of `logits.size(2)` since `logits` is of shape (1, bins, frames).
This `min` clipping along the wrong axis causes `end` to be smaller than `start` in some cases that the batch is short (less than 360 frames), leading to `nan` results during the following computations.