### PR TITLE
fix_median

### DIFF
--- a/torchcrepe/filter.py
+++ b/torchcrepe/filter.py
@@ -86,7 +86,7 @@ def median(signals, win_length):
     mask = mask.contiguous().view(mask.size()[:3] + (-1,))
 
     # Combine the mask with the input tensor
-    x_masked = torch.where(mask.bool(), x, float("inf"))
+    x_masked = torch.where(mask.bool(), x.double(), float("inf")).to(x)
 
     # Sort the masked tensor along the last dimension
     x_sorted, _ = torch.sort(x_masked, dim=-1)


### PR DESCRIPTION
https://github.com/maxrmorrison/torchcrepe/issues/23

pytorch version: 1.10.0
torchcrepe version: 0.0.19

File "/root/miniconda3/lib/python3.9/site-packages/torchcrepe/filter.py", line 90, in median
x_masked = torch.where(mask.bool(), x, float("inf"))
RuntimeError: expected scalar type float but found double

(Pdb) x.dtype
torch.float32

pd = torchcrepe.filter.median(pd, 3)
pd.dtype is float32