### PR TITLE
Fix RuntimeError when using MPS under MacOS

### DIFF
--- a/torchcrepe/load.py
+++ b/torchcrepe/load.py
@@ -27,7 +27,7 @@ def model(device, capacity='full'):
     # Load weights
     file = os.path.join(os.path.dirname(__file__), 'assets', f'{capacity}.pth')
     torchcrepe.infer.model.load_state_dict(
-        torch.load(file, map_location=device))
+        torch.load(file, map_location={'0': device}))
 
     # Place on device
     torchcrepe.infer.model = torchcrepe.infer.model.to(torch.device(device))


### PR DESCRIPTION
This fixed the error `runtimeerror: don't know how to restore data location of torch.storage.untypedstorage (tagged with mps:0)`

https://github.com/microsoft/DirectML/issues/196