### PR TITLE
bump librosa to 0.9.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author='Max Morrison',
     author_email='maxrmorrison@gmail.com',
     url='https://github.com/maxrmorrison/torchcrepe',
-    install_requires=['librosa==0.9.1', 'resampy', 'scipy', 'torch', 'tqdm'],
+    install_requires=['librosa==0.9.2', 'resampy', 'scipy', 'torch', 'tqdm'],
     packages=['torchcrepe'],
     package_data={'torchcrepe': ['assets/*']},
     long_description=long_description,


### PR DESCRIPTION
According to the documentation, it shouldn't pose any incompatibility. Meanwhile, it should resolve some other packages like RVC requiring librosa 0.9.2. 
https://librosa.org/doc/latest/changelog.html#v0-9-2