### PR TITLE
Support librosa >=0.9.1 and run tests on major librosa versions

### DIFF
--- a/.github/workflows/test-librosa-versions.yml
+++ b/.github/workflows/test-librosa-versions.yml
@@ -1,0 +1,31 @@
+name: run tests on librosa
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        librosa-version: ["0.9.1", "0.9.2", "0.10.0", "0.10.1"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . 
+          pip install librosa==${{ matrix.librosa-version }}
+      - name: Display Python version
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -c "import librosa; print(librosa.__version__)"
+      - name: Run tests
+        run: |
+          pip install pytest
+          python -m pytest

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ with open('README.md', encoding='utf8') as file:
 setup(
     name='torchcrepe',
     description='Pytorch implementation of CREPE pitch tracker',
-    version='0.0.21',
+    version='0.0.22',
     author='Max Morrison',
     author_email='maxrmorrison@gmail.com',
     url='https://github.com/maxrmorrison/torchcrepe',
-    install_requires=['librosa==0.9.1', 'resampy', 'scipy', 'torch', 'tqdm'],
+    install_requires=['librosa>=0.9.1', 'resampy', 'scipy', 'torch', 'tqdm'],
     packages=['torchcrepe'],
     package_data={'torchcrepe': ['assets/*']},
     long_description=long_description,


### PR DESCRIPTION
* added github action to test major librosa versions
    * 0.9.1, 0.9.2, 0.10.0, 0.10.1
* reviewed all librosa fn calls - as per https://github.com/maxrmorrison/torchcrepe/pull/29
    * all appear to be using args and kwargs appropriately based on * notation
* modified install dep to support librosa >=0.9.1
    * If you would like this to also support older versions, happy add tests those also
* bumped version 0.0.21 -> 0.0.22
