### PR TITLE
fix(filter): MPS framework doesn't support float64

### DIFF
--- a/torchcrepe/filter.py
+++ b/torchcrepe/filter.py
@@ -86,7 +86,7 @@ def median(signals, win_length):
     mask = mask.contiguous().view(mask.size()[:3] + (-1,))
 
     # Combine the mask with the input tensor
-    x_masked = torch.where(mask.bool(), x.double(), float("inf")).to(x)
+    x_masked = torch.where(mask.bool(), x.float(), float("inf")).to(x)
 
     # Sort the masked tensor along the last dimension
     x_sorted, _ = torch.sort(x_masked, dim=-1)


### PR DESCRIPTION
by replacing x.double() with x.float()

This change may cause a little bit accuracy loss.