### PR TITLE
FIX: PyTorch torch.load warning by using weights_only=True in torchcrepe

### DIFF
--- a/torchcrepe/load.py
+++ b/torchcrepe/load.py
@@ -22,7 +22,7 @@ def model(device, capacity='full'):
     # Load weights
     file = os.path.join(os.path.dirname(__file__), 'assets', f'{capacity}.pth')
     torchcrepe.infer.model.load_state_dict(
-        torch.load(file, map_location=device))
+        torch.load(file, map_location=device, weights_only=True))
 
     # Place on device
     torchcrepe.infer.model = torchcrepe.infer.model.to(torch.device(device))


### PR DESCRIPTION
### Summary

This PR fixes a FutureWarning raised by `torch.load` in `torchcrepe/load.py`:

> You are using torch.load with weights_only=False (the current default value), which uses the default pickle module implicitly...

PyTorch plans to change the default of `weights_only` to `True` in a future release to prevent unintentional execution of pickled code. Since the `.pth` files in torchcrepe are state_dicts (not full pickled models), we explicitly pass `weights_only=True` to safely suppress the warning.

### Details

- Modified `torch.load(...)` in `load.py` to use `weights_only=True`
- This avoids potential future issues and cleans up the console output
- Model behavior remains unchanged


### System

- PyTorch 2.5.1+cu124
- Ubuntu 20.04 LTS

### Reference

- [PyTorch Security Policy on Untrusted Models](https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models)